### PR TITLE
New annotation for generating functions in typescript

### DIFF
--- a/annotations/src/main/java/dz/jtsgen/annotations/TypeScriptExecutable.java
+++ b/annotations/src/main/java/dz/jtsgen/annotations/TypeScriptExecutable.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Dragan Zuvic
+ *
+ * This file is part of jtsgen.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package dz.jtsgen.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * classes and interfaces used by this annotation will be included to the exported type script module
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(value = {ElementType.TYPE}) // FUTURE: ElementType.METHOD, ElementType.FIELD
+public @interface TypeScriptExecutable {
+}

--- a/processor/src/main/java/dz/jtsgen/processor/jtp/conv/DefaultJavaTypeConverter.java
+++ b/processor/src/main/java/dz/jtsgen/processor/jtp/conv/DefaultJavaTypeConverter.java
@@ -54,10 +54,10 @@ public class DefaultJavaTypeConverter implements JavaTypeConverter {
 
     private final TypeElement javaLangObjectElement;
     private final TypeElement javaLangEnumElement;
-    private final TSProcessingInfo processingInfo;
+    protected final TSProcessingInfo processingInfo;
 
 
-    private static final Logger LOG = Logger.getLogger(TypeScriptAnnotationProcessor.class.getName());
+    protected static final Logger LOG = Logger.getLogger(TypeScriptAnnotationProcessor.class.getName());
 
     DefaultJavaTypeConverter(TSProcessingInfo processingInfo) {
         this.processingInfo = processingInfo;
@@ -113,14 +113,14 @@ public class DefaultJavaTypeConverter implements JavaTypeConverter {
                             .withDocumentString(commentFrom(element));
                 }
                 else {
-                    result = TSInterfaceBuilder.of(element)
+                result = TSInterfaceBuilder.of(element)
                             .withName(getName(element, annotation))
                             .withMembers(visitor.getMembers())
                             .withConstants(visitor.getConstants())
                             .withMethods(visitor.getMethods())
-                            .withSuperTypes(supertypes)
-                            .withTypeParams(typeParams)
-                            .withDocumentString(commentFrom(element));
+                        .withSuperTypes(supertypes)
+                        .withTypeParams(typeParams)
+                        .withDocumentString(commentFrom(element));
                 }
 
                 break;

--- a/processor/src/main/java/dz/jtsgen/processor/jtp/conv/JavaTypeElementExtractingVisitor.java
+++ b/processor/src/main/java/dz/jtsgen/processor/jtp/conv/JavaTypeElementExtractingVisitor.java
@@ -46,22 +46,22 @@ class JavaTypeElementExtractingVisitor extends SimpleElementVisitor8<Void, Void>
     private static Logger LOG = Logger.getLogger(JavaTypeElementExtractingVisitor.class.getName());
 
 
-    private final Map<String, TSMember> members = new HashMap<>();
+    protected final Map<String, TSMember> members = new HashMap<>();
     private final Map<String, TSConstant> constants = new HashMap<>();
 
     private final List<TSMethod> methods = new ArrayList<>();
 
     // list of members to sort out setters only
-    private final Set<String> extractableMembers = new HashSet<>();
+    protected final Set<String> extractableMembers = new HashSet<>();
 
     // the current Java Type
-    private final TypeElement typeElementToConvert;
+    protected final TypeElement typeElementToConvert;
 
     // the environment
-    private TSProcessingInfo tsProcessingInfo;
+    protected TSProcessingInfo tsProcessingInfo;
 
     // the converter for unknown types
-    private JavaTypeConverter javaTypeConverter;
+    protected JavaTypeConverter javaTypeConverter;
 
 
 
@@ -85,7 +85,7 @@ class JavaTypeElementExtractingVisitor extends SimpleElementVisitor8<Void, Void>
         final boolean isPublic = e.getModifiers().contains(Modifier.PUBLIC);
         final String name = nameOfConstant(e);
         final boolean isIgnored = isIgnored(e);
-        final boolean isReadOnlyAnnotation = readOnlyAnnotation(e) || readOnlyAnnotation(this.typeElementToConvert);
+        final boolean  isReadOnlyAnnotation = readOnlyAnnotation(e) || readOnlyAnnotation(this.typeElementToConvert);
         LOG.log(Level.FINEST, () -> String.format("JTExV visiting variable %s%s", name, isIgnored?" (ignored)":""));
 
 
@@ -221,11 +221,11 @@ class JavaTypeElementExtractingVisitor extends SimpleElementVisitor8<Void, Void>
                 .withComment(comment));
     }
 
-    private String mappedName(String rawName) {
+    protected String mappedName(String rawName) {
         return this.tsProcessingInfo.nameMapper().mapMemberName(rawName);
     }
 
-    private boolean isGetter(ExecutableElement e) {
+    protected boolean isGetter(ExecutableElement e) {
         return this.tsProcessingInfo.executableHelper().isGetter(e);
     }
 
@@ -257,7 +257,7 @@ class JavaTypeElementExtractingVisitor extends SimpleElementVisitor8<Void, Void>
         return this.tsProcessingInfo.executableHelper().isGetterOrSetter(e);
     }
 
-    private boolean readOnlyAnnotation(Element e) {
+    protected boolean readOnlyAnnotation(Element e) {
         final TypeElement annoTationElement = this.tsProcessingInfo.elementCache().typeElementByCanonicalName(TSReadOnly.class.getCanonicalName());
         return e.getAnnotationMirrors().stream().anyMatch( (x) ->
                 x.getAnnotationType().asElement().equals(annoTationElement)
@@ -271,7 +271,7 @@ class JavaTypeElementExtractingVisitor extends SimpleElementVisitor8<Void, Void>
         );
     }
 
-    private boolean isIgnored(Element e) {
+    protected boolean isIgnored(Element e) {
         final TypeElement annoTationElement = this.tsProcessingInfo.elementCache().typeElementByCanonicalName(TSIgnore.class.getCanonicalName());
         return e.getAnnotationMirrors().stream().anyMatch( (x) ->
                 x.getAnnotationType().asElement().equals(annoTationElement));
@@ -282,7 +282,7 @@ class JavaTypeElementExtractingVisitor extends SimpleElementVisitor8<Void, Void>
         return new MirrorTypeToTSConverterVisitor(theElement, tsProcessingInfo, javaTypeConverter).visit(theElement.getReturnType());
     }
 
-    private TSTargetType convertTypeMirrorOfMemberToTsType(VariableElement theElement, TSProcessingInfo TSProcessingInfo) {
+    protected TSTargetType convertTypeMirrorOfMemberToTsType(VariableElement theElement, TSProcessingInfo TSProcessingInfo) {
         return new MirrorTypeToTSConverterVisitor(theElement, TSProcessingInfo, javaTypeConverter).visit(theElement.asType());
     }
 

--- a/processor/src/main/java/dz/jtsgen/processor/jtp/conv/PreserveExecutablesJavaTypeConverter.java
+++ b/processor/src/main/java/dz/jtsgen/processor/jtp/conv/PreserveExecutablesJavaTypeConverter.java
@@ -1,0 +1,25 @@
+package dz.jtsgen.processor.jtp.conv;
+
+import java.util.Collection;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+
+import dz.jtsgen.processor.jtp.info.TSProcessingInfo;
+import dz.jtsgen.processor.model.TSMember;
+
+public class PreserveExecutablesJavaTypeConverter extends DefaultJavaTypeConverter {
+
+  PreserveExecutablesJavaTypeConverter(TSProcessingInfo processingInfo) {
+    super(processingInfo);
+  }
+
+  // TODO: the member lookup has changed in HEAD vs. the 0.5.0 release -- this needs to be updated for the new lookup scheme
+  protected Collection<? extends TSMember> findMembers(TypeElement e) {
+    LOG.fine(() -> "DJTC find members in  in java type " + e);
+    JavaTypeElementExtractingVisitor visitor = new PreserveExecutablesJavaTypeElementExtractingVisitor(e, processingInfo, this);
+    e.getEnclosedElements().stream()
+        .filter(x -> x.getKind() == ElementKind.FIELD || x.getKind() == ElementKind.METHOD)
+        .forEach(visitor::visit);
+    return visitor.getMembers();
+  }
+}

--- a/processor/src/main/java/dz/jtsgen/processor/jtp/conv/PreserveExecutablesJavaTypeElementExtractingVisitor.java
+++ b/processor/src/main/java/dz/jtsgen/processor/jtp/conv/PreserveExecutablesJavaTypeElementExtractingVisitor.java
@@ -1,0 +1,77 @@
+package dz.jtsgen.processor.jtp.conv;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Logger;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.util.AbstractTypeVisitor8;
+
+import dz.jtsgen.processor.jtp.conv.visitors.JavaTypeConverter;
+import dz.jtsgen.processor.jtp.info.TSProcessingInfo;
+import dz.jtsgen.processor.model.TSExecutableMemberBuilder;
+import dz.jtsgen.processor.model.TSRegularMember;
+import dz.jtsgen.processor.model.TSRegularMemberBuilder;
+import dz.jtsgen.processor.model.TSTargetType;
+
+class PreserveExecutablesJavaTypeElementExtractingVisitor extends JavaTypeElementExtractingVisitor {
+  private static Logger LOG = Logger.getLogger(PreserveExecutablesJavaTypeElementExtractingVisitor.class.getName());
+
+  PreserveExecutablesJavaTypeElementExtractingVisitor(TypeElement typeElementToConvert, TSProcessingInfo visitorParam, JavaTypeConverter javaTypeConverter) {
+    super(typeElementToConvert,visitorParam,javaTypeConverter);
+  }
+
+  @Override
+  public Void visitExecutable(ExecutableElement e, Void notcalled) {
+    LOG.fine(() -> String.format("JTExV visiting executable %s", e.toString()));
+    final String rawName = e.getSimpleName().toString();  //  nameOfMethod(e).orElse("");
+    final String name = mappedName(rawName);
+    final boolean isPublic = e.getModifiers().contains(Modifier.PUBLIC);
+    final boolean isIgnored = isIgnored(e);
+    final boolean isReadOnly = readOnlyAnnotation(e) || readOnlyAnnotation(this.typeElementToConvert);
+    final boolean isInit = rawName.startsWith("<");
+    if (!isPublic ||  isIgnored || isInit) return null; // return early for not converting private types
+    final TSTargetType returnType = convertTypeMirrorToTsType(e, tsProcessingInfo);
+    LOG.fine(() -> "is getter or setter: " + (isPublic ? "public " : " ") + e.getSimpleName() + " -> " + name +"(" + rawName+ ")" + ":" + returnType + " " +(isIgnored?"(ignored)":""));
+
+
+    final List<TSRegularMember> paramMembers = new ArrayList<>();
+    final List<? extends VariableElement> functionParams = e.getParameters();
+    for (VariableElement functionParam : functionParams) {
+      final String paramName = functionParam.getSimpleName().toString();
+      final TSTargetType paramType = convertTypeMirrorOfMemberToTsType(functionParam, tsProcessingInfo);
+      paramMembers.add(TSRegularMemberBuilder.of(paramName, paramType, false));
+    }
+
+    final TSRegularMember [] parameters = paramMembers.toArray(new TSRegularMember[0]);
+    if (members.containsKey(name)) {
+      // can't be read only anymore
+      final Optional<String> comment = Optional.ofNullable(this.tsProcessingInfo.getpEnv().getElementUtils().getDocComment(e));
+      members.put(name, TSExecutableMemberBuilder
+          .of(
+              name,
+              isGetter(e) ? returnType : members.get(name).getType(),
+              isReadOnly,
+              parameters)
+          .withComment(comment)
+      );
+    } else {
+      final Optional<String> comment = Optional.ofNullable(this.tsProcessingInfo.getpEnv().getElementUtils().getDocComment(e));
+      members.put(name, TSExecutableMemberBuilder
+          .of(name, returnType, isReadOnly, parameters)
+          .withComment(comment)
+      );
+    }
+    extractableMembers.add(name);
+    return null;
+  }
+
+  protected TSTargetType convertTypeMirrorToTsType(ExecutableElement theElement, TSProcessingInfo tsProcessingInfo) {
+    AbstractTypeVisitor8<TSTargetType, Void> visitor = new MirrorTypeToTSConverterVisitor(theElement, tsProcessingInfo, javaTypeConverter);
+    return visitor.visit(theElement.getReturnType());
+  }
+
+}

--- a/processor/src/main/java/dz/jtsgen/processor/jtp/conv/PreserveExecutablesTypeScriptAnnotationProcessor.java
+++ b/processor/src/main/java/dz/jtsgen/processor/jtp/conv/PreserveExecutablesTypeScriptAnnotationProcessor.java
@@ -1,0 +1,10 @@
+package dz.jtsgen.processor.jtp.conv;
+
+import dz.jtsgen.processor.jtp.info.TSProcessingInfo;
+
+public class PreserveExecutablesTypeScriptAnnotationProcessor extends TypeScriptAnnotationProcessor {
+
+  public PreserveExecutablesTypeScriptAnnotationProcessor(TSProcessingInfo processingInfo) {
+    super(processingInfo, new PreserveExecutablesJavaTypeConverter(processingInfo));
+  }
+}

--- a/processor/src/main/java/dz/jtsgen/processor/jtp/conv/TypeScriptAnnotationProcessor.java
+++ b/processor/src/main/java/dz/jtsgen/processor/jtp/conv/TypeScriptAnnotationProcessor.java
@@ -55,6 +55,11 @@ public class TypeScriptAnnotationProcessor implements JavaTypeProcessor {
         javaConverter = new DefaultJavaTypeConverter(processingInfo);
     }
 
+   protected TypeScriptAnnotationProcessor(TSProcessingInfo processingInfo, JavaTypeConverter javaConverter) {
+     this.processingInfo = processingInfo;
+     this.javaConverter = javaConverter;
+   }
+
     @Override
     public void processAnnotations(RoundEnvironment roundEnv) {
           this.processElements(

--- a/processor/src/main/java/dz/jtsgen/processor/jtp/helper/RoundEnvHelper.java
+++ b/processor/src/main/java/dz/jtsgen/processor/jtp/helper/RoundEnvHelper.java
@@ -22,11 +22,13 @@ package dz.jtsgen.processor.jtp.helper;
 
 import dz.jtsgen.annotations.TSIgnore;
 import dz.jtsgen.annotations.TypeScript;
+import dz.jtsgen.annotations.TypeScriptExecutable;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import java.util.Set;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -36,10 +38,19 @@ public abstract class RoundEnvHelper {
     
     public static Set<Element> filteredTypeSriptElements(RoundEnvironment roundEnv) {
         final String tsIgnoreSimpleName = TSIgnore.class.getSimpleName();
-        return roundEnv.getElementsAnnotatedWith(TypeScript.class).<Element>stream()
-                .filter(
-                        (ignoring) -> ignoring.getAnnotationMirrors().<AnnotationMirror>stream().noneMatch(
-                                (y) -> tsIgnoreSimpleName.equals(y.getAnnotationType().asElement().getSimpleName().toString())))
-                .collect(Collectors.toSet());
+        Predicate<Element> pred = new Predicate<Element>() {
+            @Override public boolean test(Element element) {
+                return element.getAnnotationMirrors().<AnnotationMirror>stream().noneMatch(
+                    (y) -> tsIgnoreSimpleName.equals(y.getAnnotationType().asElement().getSimpleName().toString()));
+            }
+        };
+
+        Set<? extends Element> tsElems = roundEnv.getElementsAnnotatedWith(TypeScript.class);
+        Set<? extends Element> tseElems = roundEnv.getElementsAnnotatedWith(TypeScriptExecutable.class);
+        Set<Element> a = tsElems.<Element>stream().filter(pred).collect(Collectors.toSet());
+        Set<Element> b = tseElems.<Element>stream().filter(pred).collect(Collectors.toSet());
+        a.addAll(b);
+        return a;
     }
+
 }

--- a/processor/src/main/java/dz/jtsgen/processor/model/TSExecutableMember.java
+++ b/processor/src/main/java/dz/jtsgen/processor/model/TSExecutableMember.java
@@ -1,0 +1,50 @@
+package dz.jtsgen.processor.model;
+
+import java.util.Optional;
+
+import org.immutables.value.Value;
+
+import dz.jtsgen.processor.model.rendering.TSMemberVisitor;
+
+@Value.Immutable
+public abstract class TSExecutableMember implements TSMember {
+
+  @Value.Parameter
+  public abstract String getName() ;
+
+  @Value.Parameter
+  public abstract TSTargetType getType();
+
+  @Value.Parameter
+  public abstract boolean getReadOnly();
+
+  @Value.Default
+  public boolean getNullable() {
+    return false;
+  }
+
+  @Value.Default
+  public boolean getOptional() {
+    return false;
+  }
+
+  public abstract Optional<String> getComment();
+
+  @Value.Default
+  public boolean getInvalid() {
+    return false;
+  }
+
+  @Value.Parameter
+  public abstract TSRegularMember[] getParameters();
+
+  @Override
+  public void accept(TSMemberVisitor visitor, int ident) {
+    visitor.visit(this, ident);
+  }
+
+  @Override
+  public TSMember changedTSTarget(TSTargetType newTargetType) {
+    return TSExecutableMemberBuilder.copyOf(this).withType(newTargetType);
+  }
+}

--- a/processor/src/main/java/dz/jtsgen/processor/model/rendering/TSMemberVisitor.java
+++ b/processor/src/main/java/dz/jtsgen/processor/model/rendering/TSMemberVisitor.java
@@ -22,9 +22,11 @@ package dz.jtsgen.processor.model.rendering;
 
 
 import dz.jtsgen.processor.model.TSEnumMember;
+import dz.jtsgen.processor.model.TSExecutableMember;
 import dz.jtsgen.processor.model.TSMember;
 
 public interface TSMemberVisitor {
     void visit(TSMember x, int ident);
     void visit(TSEnumMember x, int ident);
+    void visit(TSExecutableMember x, int ident);
 }

--- a/processor/src/main/java/dz/jtsgen/processor/renderer/module/tsd/DefaultTSMemberVisitor.java
+++ b/processor/src/main/java/dz/jtsgen/processor/renderer/module/tsd/DefaultTSMemberVisitor.java
@@ -22,8 +22,10 @@ package dz.jtsgen.processor.renderer.module.tsd;
 
 import dz.jtsgen.processor.helper.IdentHelper;
 import dz.jtsgen.processor.model.TSEnumMember;
+import dz.jtsgen.processor.model.TSExecutableMember;
 import dz.jtsgen.processor.model.TSMember;
 import dz.jtsgen.processor.model.TSMethodMember;
+import dz.jtsgen.processor.model.TSRegularMember;
 import dz.jtsgen.processor.model.rendering.TSMemberVisitor;
 import dz.jtsgen.processor.model.rendering.TSMethodVisitor;
 
@@ -53,10 +55,38 @@ public class DefaultTSMemberVisitor extends OutputVisitor implements TSMemberVis
         getOut().print(x.getType());
         if(x.getNullable()) {
             getOut().print(" | null");
-        }
+            }
         getOut().println(";");
     }
 
+    @Override
+    public void visit(TSExecutableMember x, int ident) {
+        x.getComment().ifPresent( comment -> tsComment(comment,ident));
+        getOut().print(IdentHelper.identPrefix(ident));
+        if (x.getReadOnly()) getOut().print("readonly ");
+        getOut().print(x.getName());
+        getOut().print("(");
+        TSRegularMember[] parameters = x.getParameters();
+        if(parameters != null && parameters.length > 0) {
+            boolean first = true;
+            for (TSRegularMember parameter : parameters) {
+                if(parameter != null) {
+                    if(first) {
+                        first = false;
+                    } else {
+                        getOut().print(",");
+                    }
+                    getOut().print(parameter.getName());
+                    getOut().print(": ");
+                    getOut().print(parameter.getType());
+                }
+            }
+        }
+        getOut().print(")");
+        getOut().print(": ");
+        getOut().print(x.getType());
+        getOut().println(";");
+    }
     @Override
     public void visit(TSEnumMember x, int ident) {
         x.getComment().ifPresent( comment -> tsComment(comment,ident));
@@ -93,7 +123,7 @@ public class DefaultTSMemberVisitor extends OutputVisitor implements TSMemberVis
                     }
                     else {
                         arg = entry.getKey() + ": " + entry.getValue().toString();
-                    }
+        }
                     if(entry.getValue().isNullable()) {
                         arg += " | null";
                     }


### PR DESCRIPTION
Hi Dragan,

Thanks for this excellent project! We are building typescript code that interoperates with java through a browser embedded in the Java UI (https://www.teamdev.com/jxbrowser).  jtsgen is perfect for keeping the consumed and supplied data types synchronized. There is one limitation in that our "bridge" object for making calls from javascript into java cannot be modeled with the @TypeScript annotation. We want methods in the java interface to be functions in the TypeScript interface.

This patch is more of a proof-of-concept or a demonstration, although it is suitable for our needs.  It introduces a new "@TypeScriptExecutable" annotation that generates TypeScript functions from Java methods rather than converting bean properties to TypeScript properties.

Here's an example of the generated output:
`export interface JavaBridge {
    getScaleFactors(): ScaleFactors;
    getHorizonEditsPreview(): PolylineInfo;  
    getDisplayNameFromGuid(guid: string): string;
...`

from the java:
`@TypeScriptExecutable
public interface JavaBridge {
  ScaleFactors getScaleFactors();
  PolylineInfo getHorizonEditsPreview();
  String getDisplayNameFromGuid(String guid);
...`

Notes on the changes to the 0.5.0 release:

[README.txt](https://github.com/dzuvic/jtsgen/files/6874333/README.txt)
